### PR TITLE
Add ProcesorID, User TIme, Kernel Time to event metadata

### DIFF
--- a/etw/advapi32_header.go
+++ b/etw/advapi32_header.go
@@ -746,9 +746,18 @@ type EventHeader struct {
 	TimeStamp       int64
 	ProviderId      GUID
 	EventDescriptor EventDescriptor
-    KernelTime  	uint32
-    UserTime   		uint32
+    ProcessorTime   uint64      // Processor Clock (KernelTime | UserTime)
 	ActivityId      GUID
+}
+
+func (e *EventHeader) GetKernelTime() uint32 {
+	// Extract KernelTime (higher 32 bits)
+	return uint32(e.ProcessorTime >> 32)
+}
+
+func (e *EventHeader) GetUserTime() uint32 {
+	// Extract UserTime (lower 32 bits)
+	return uint32(e.ProcessorTime & 0xFFFFFFFF)
 }
 
 func (e *EventHeader) UTCTimeStamp() time.Time {

--- a/etw/advapi32_header.go
+++ b/etw/advapi32_header.go
@@ -808,7 +808,7 @@ typedef struct _ETW_BUFFER_CONTEXT {
     struct {
       UCHAR ProcessorNumber;
       UCHAR Alignment;
-    } DUMMYSTRUCTNAME; // siize UCHAR
+    } DUMMYSTRUCTNAME; // size UCHAR
     USHORT ProcessorIndex; // USHORT
   } DUMMYUNIONNAME; // USHORT
   USHORT LoggerId;
@@ -816,8 +816,9 @@ typedef struct _ETW_BUFFER_CONTEXT {
 */
 // sizeof: 0x4 (OK)
 type EtwBufferContext struct {
-	Union    uint16
-	LoggerId uint16
+	Processor uint8 // The number of the CPU on which the provider process was running. The number is zero on a single processor computer.
+	Alignment uint8 // Alignment between events (always eight).
+	LoggerId uint16 // Identifier of the session that logged the event.
 }
 
 /*

--- a/etw/advapi32_header.go
+++ b/etw/advapi32_header.go
@@ -746,8 +746,8 @@ type EventHeader struct {
 	TimeStamp       int64
 	ProviderId      GUID
 	EventDescriptor EventDescriptor
-    KernelTime  uint32
-    UserTime   uint32
+    KernelTime  	uint32
+    UserTime   		uint32
 	ActivityId      GUID
 }
 

--- a/etw/advapi32_header.go
+++ b/etw/advapi32_header.go
@@ -746,7 +746,8 @@ type EventHeader struct {
 	TimeStamp       int64
 	ProviderId      GUID
 	EventDescriptor EventDescriptor
-	Time            int64
+    KernelTime  uint32
+    UserTime   uint32
 	ActivityId      GUID
 }
 

--- a/etw/advapi32_header.go
+++ b/etw/advapi32_header.go
@@ -751,13 +751,13 @@ type EventHeader struct {
 }
 
 func (e *EventHeader) GetKernelTime() uint32 {
-	// Extract KernelTime (higher 32 bits)
-	return uint32(e.ProcessorTime >> 32)
+	// Extract KernelTime (lower 32 bits)
+	return uint32(e.ProcessorTime & 0xFFFFFFFF)
 }
 
 func (e *EventHeader) GetUserTime() uint32 {
-	// Extract UserTime (lower 32 bits)
-	return uint32(e.ProcessorTime & 0xFFFFFFFF)
+    // Extract UserTime (higher 32 bits)
+	return uint32(e.ProcessorTime >> 32)
 }
 
 func (e *EventHeader) UTCTimeStamp() time.Time {

--- a/etw/etw_helpers.go
+++ b/etw/etw_helpers.go
@@ -159,8 +159,8 @@ func (e *EventRecordHelper) setEventMetadata(event *Event) {
 	event.System.Execution.ProcessID = e.EventRec.EventHeader.ProcessId
 	event.System.Execution.ThreadID = e.EventRec.EventHeader.ThreadId
 	event.System.Execution.ProcessorID = uint16(e.EventRec.BufferContext.Processor)
-	event.System.Execution.KernelTime = uint32(e.EventRec.EventHeader.Time & 0xFFFFFFFF) // TODO: for private session use Time
-	event.System.Execution.UserTime = uint32((e.EventRec.EventHeader.Time >> 32) & 0xFFFFFFFF); // TODO: for private session use Time
+	event.System.Execution.KernelTime = e.EventRec.EventHeader.KernelTime // NOTE: for private session use uint64(KernelTime << 32) | UserTime
+	event.System.Execution.UserTime = e.EventRec.EventHeader.UserTime // NOTE: for private session use Time
 	event.System.Correlation.ActivityID = e.EventRec.EventHeader.ActivityId.String()
 	event.System.Correlation.RelatedActivityID = e.EventRec.RelatedActivityID()
 	event.System.EventID = e.TraceInfo.EventID()

--- a/etw/etw_helpers.go
+++ b/etw/etw_helpers.go
@@ -159,8 +159,8 @@ func (e *EventRecordHelper) setEventMetadata(event *Event) {
 	event.System.Execution.ProcessID = e.EventRec.EventHeader.ProcessId
 	event.System.Execution.ThreadID = e.EventRec.EventHeader.ThreadId
 	event.System.Execution.ProcessorID = uint16(e.EventRec.BufferContext.Processor)
-	event.System.Execution.KernelTime = e.EventRec.EventHeader.KernelTime // NOTE: for private session use uint64(KernelTime << 32) | UserTime
-	event.System.Execution.UserTime = e.EventRec.EventHeader.UserTime // NOTE: for private session use Time
+	event.System.Execution.KernelTime = e.EventRec.EventHeader.GetKernelTime() // NOTE: for private session use e.EventRec.EventHeader.ProcessorTime
+	event.System.Execution.UserTime = e.EventRec.EventHeader.GetUserTime() // NOTE: for private session use e.EventRec.EventHeader.ProcessorTime
 	event.System.Correlation.ActivityID = e.EventRec.EventHeader.ActivityId.String()
 	event.System.Correlation.RelatedActivityID = e.EventRec.RelatedActivityID()
 	event.System.EventID = e.TraceInfo.EventID()

--- a/etw/etw_helpers.go
+++ b/etw/etw_helpers.go
@@ -158,6 +158,9 @@ func (e *EventRecordHelper) setEventMetadata(event *Event) {
 	event.System.Computer = hostname
 	event.System.Execution.ProcessID = e.EventRec.EventHeader.ProcessId
 	event.System.Execution.ThreadID = e.EventRec.EventHeader.ThreadId
+	event.System.Execution.ProcessorID = uint16(e.EventRec.BufferContext.Processor)
+	event.System.Execution.KernelTime = uint32(e.EventRec.EventHeader.Time & 0xFFFFFFFF) // TODO: for private session use Time
+	event.System.Execution.UserTime = uint32((e.EventRec.EventHeader.Time >> 32) & 0xFFFFFFFF); // TODO: for private session use Time
 	event.System.Correlation.ActivityID = e.EventRec.EventHeader.ActivityId.String()
 	event.System.Correlation.RelatedActivityID = e.EventRec.RelatedActivityID()
 	event.System.EventID = e.TraceInfo.EventID()

--- a/etw/event.go
+++ b/etw/event.go
@@ -27,6 +27,9 @@ type Event struct {
 		Execution struct {
 			ProcessID uint32
 			ThreadID  uint32
+			ProcessorID uint16
+			KernelTime uint32
+			UserTime uint32
 		}
 		Keywords struct {
 			Value uint64

--- a/etw/tdh_headers.go
+++ b/etw/tdh_headers.go
@@ -18,7 +18,7 @@ typedef struct _TDH_CONTEXT {
 */
 
 type TdhContext struct {
-	ParameterValue uint32
+	ParameterValue uint64
 	ParameterType  TdhContextType
 	ParameterSize  uint32
 }


### PR DESCRIPTION
Adds missing fields to event header
ProcesorID, User TIme, Kernel Time

Fixes #4 